### PR TITLE
Update Sklearn Tutorial (Binary Text Classification).ipynb

### DIFF
--- a/Sklearn Tutorial (Binary Text Classification).ipynb
+++ b/Sklearn Tutorial (Binary Text Classification).ipynb
@@ -165,7 +165,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "df_review = pd.read_csv('IMDB Dataset.csv')\n",
+    "df_review =  pd.read_csv('IMDB Dataset.csv',error_bad_lines=False, engine ='python', encoding='utf8')\n",
     "df_review"
    ]
   },


### PR DESCRIPTION
Simply putting the data file in the read_csv function wasn't working.  Was always giving the error 

> “Error tokenising data. C error: EOF inside string starting at line”.

The solution is to use the parameter `engine='python'` inside the read_csv function call. Since pandas uses Python and C(default) engines to parse the CSV file.

To remove the 

> “UnicodeDecodeError: ‘utf-8’ codec can’t decode byte 0x96 in position XX: invalid start byte”

we should add `encoding='utf8'` to the read_csv command.

And for removing the error that came after it 

> ParserError: unexpected end of data

either add `erro_bad_lines= False`

It skips the last line, or if you don't want to do that, use the Quote_None from csv library